### PR TITLE
Fix 'importsNotUsedAsValues' Error

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "toeat",
+      "name": "toeat-mvc-workshop",
       "version": "0.0.0",
       "dependencies": {
         "@types/uuid": "^8.3.4",

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -7,11 +7,16 @@ export default {
     TheNavbar,
     TheFooter,
   },
+  setup: () => ({
+    tagline: 123,
+  }),
 }
 </script>
 
 <template>
-  <TheNavbar />
+  <!-- Can bring in props from components this way too, though not recommended -->
+  <!-- <TheNavbar tagline="Track Everything you Want to Eat!" /> -->
+  <TheNavbar :tagline="tagline" />
   <RouterView />
   <TheFooter />
 </template>

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -8,7 +8,7 @@ export default {
     TheFooter,
   },
   setup: () => ({
-    tagline: 123,
+    tagline: 'Track everything you want to DEVOUR',
   }),
 }
 </script>

--- a/app/src/components/RestaurantCard.vue
+++ b/app/src/components/RestaurantCard.vue
@@ -1,4 +1,15 @@
 <script>
+/**
+ * Restaurant
+ */
+// {
+//   id: string
+//   name: string
+//   address: string
+//   website: string
+//   status: string
+// }
+
 export default {
   props: {
     restaurant: {

--- a/app/src/components/TheNavbar.vue
+++ b/app/src/components/TheNavbar.vue
@@ -1,6 +1,12 @@
 <script>
 export default {
-  props: ['tagline'],
+  //props can be an array, but an object allows you to define types
+  props: {
+    tagline: {
+      type: [String, Number],
+      default: 'Track everything you want to eat!',
+    },
+  },
   data: () => ({
     navList: [
       {

--- a/app/tsconfig.config.json
+++ b/app/tsconfig.config.json
@@ -3,6 +3,9 @@
   "include": ["vite.config.*", "vitest.config.*", "cypress.config.*"],
   "compilerOptions": {
     "composite": true,
+    "verbatimModuleSyntax": true,
+    "importsNotUsedAsValues": "remove",
+    "preserveValueImports": false,
     "types": ["node"]
   }
 }

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -4,6 +4,9 @@
   "compilerOptions": {
     "allowJs": true,
     "baseUrl": ".",
+    "verbatimModuleSyntax": true,
+    "importsNotUsedAsValues": "remove",
+    "preserveValueImports": false,
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
In both ts.config files, it's giving an error that says:

> Option 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. 
> Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
>   Use 'verbatimModuleSyntax' instead.

The addition of these three statements to both config files in `compilerOptions` fixes that error:

```
    "verbatimModuleSyntax": true,
    "importsNotUsedAsValues": "remove",
    "preserveValueImports": false,
```

I believe the reason for that error is a deprecated rule on older versions of TypeScript. As of today (03/16/24), TypeScript is on version 5.4 and without those additions to the config files, there may be issues once it reaches 5.5.